### PR TITLE
Fix BotPlugin.rooms() trying to call a set

### DIFF
--- a/errbot/botplugin.py
+++ b/errbot/botplugin.py
@@ -372,7 +372,7 @@ class BotPlugin(BotPluginBase):
         """
         The list of rooms the bot is currently in.
         """
-        return self._bot.rooms()
+        return self._bot.rooms
 
     def query_room(self, room):
         """


### PR DESCRIPTION
At least for the HipChat backend, the _bot object contains a set of rooms, rather than a rooms() method.